### PR TITLE
Remove the lock before the job is peformed

### DIFF
--- a/lib/resque/plugins/dedup.rb
+++ b/lib/resque/plugins/dedup.rb
@@ -23,11 +23,12 @@ module Resque
       # Cleanup the key after the job is done.
       def around_perform_lock(*args)
         begin
+          Resque.redis.del(lock(*args))
           yield
         ensure
           # Always clear the lock when we're done, even if there is an
           # error.
-          Resque.redis.del(lock(*args))
+          Resque.redis.del(lock(*args)) if Resque.redis.exists(lock(*args))
         end
       end
     end

--- a/test/dedup_test.rb
+++ b/test/dedup_test.rb
@@ -7,7 +7,7 @@ class Job
   @queue = :test
 
   def self.perform
-    sleep 1
+    Resque.enqueue(Job)
   end
 end
 
@@ -23,6 +23,6 @@ class DedupTest < Test::Unit::TestCase
     assert_equal 1, Resque.size(:test)
     worker = Resque::Worker.new(:test)
     worker.process
-    assert_equal 0, Resque.size(:test)
+    assert_equal 1, Resque.size(:test)
   end
 end


### PR DESCRIPTION
If another job is queued after perform is finished, but before the lock is removed, it will be dropped. Consider if this job looks up an object and does something depending on the sets a value based on the current state of the object. If another job is queued because the object changed again between when the object is looked up and when the lock is removed, it will not have the value it sets is no longer accurate, but the job won't be queued again to update it.
